### PR TITLE
Add PR Hugo build-test workflow and remove non-deterministic `hugo mod get -u` from deploy

### DIFF
--- a/.github/workflows/hugo-build-test.yml
+++ b/.github/workflows/hugo-build-test.yml
@@ -1,0 +1,39 @@
+name: Hugo build test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.146.0
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Node.js dependencies
+        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+      - name: Build with Hugo
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo \
+            --minify \
+            --baseURL "https://douyixuan.github.io/"

--- a/.github/workflows/hugo-build-test.yml
+++ b/.github/workflows/hugo-build-test.yml
@@ -34,7 +34,7 @@ jobs:
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
-          hugo mod get
+          hugo mod tidy
           hugo \
             --minify \
             --baseURL "https://douyixuan.github.io/"

--- a/.github/workflows/hugo-build-test.yml
+++ b/.github/workflows/hugo-build-test.yml
@@ -21,8 +21,12 @@ jobs:
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
       - name: Install Dart Sass
-        run: sudo snap install dart-sass
+        run: npm install --global sass
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/hugo-build-test.yml
+++ b/.github/workflows/hugo-build-test.yml
@@ -34,6 +34,7 @@ jobs:
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
+          hugo mod get
           hugo \
             --minify \
             --baseURL "https://douyixuan.github.io/"

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -54,6 +54,7 @@ jobs:
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
+          hugo mod get
           hugo \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -37,8 +37,12 @@ jobs:
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
       - name: Install Dart Sass
-        run: sudo snap install dart-sass
+        run: npm install --global sass
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -54,7 +54,7 @@ jobs:
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
-          hugo mod get
+          hugo mod tidy
           hugo \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -54,7 +54,6 @@ jobs:
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
-          hugo mod get -u && \
           hugo \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"


### PR DESCRIPTION
### Motivation
- The deploy builds were failing due to non-deterministic upstream Hugo module updates during `hugo mod get -u` in CI. 
- Add a lightweight PR/build-only check so pull requests get an early Hugo build validation before merge.

### Description
- Add ` .github/workflows/hugo-build-test.yml` which runs on `pull_request` and `workflow_dispatch` and performs a read-only Hugo build using the same CLI and Sass install steps as production. 
- Keep the test workflow permissions to `contents: read` so it does not attempt any Pages deployment. 
- Remove `hugo mod get -u` from the production deploy workflow in `.github/workflows/hugo.yml` so CI builds use pinned dependencies from `go.mod/go.sum` and are more deterministic.

### Testing
- No automated CI runs were executed as part of this change; the new `hugo-build-test` workflow will run automatically on new pull requests and can be triggered manually via `workflow_dispatch` to validate builds. 
- Local repository checks (`git diff` / `git commit`) completed successfully to stage and record the workflow changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fec82be3e48329891cdee9b672a041)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated build testing workflow to validate site builds on pull requests
  * Streamlined the build process by removing an unnecessary initialization step

<!-- end of auto-generated comment: release notes by coderabbit.ai -->