### PR TITLE
Add Hugo build-test workflow, use `hugo mod tidy`, and fix GPU SIMT post frontmatter

### DIFF
--- a/.github/workflows/hugo-build-test.yml
+++ b/.github/workflows/hugo-build-test.yml
@@ -1,0 +1,40 @@
+name: Hugo build test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.146.0
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Node.js dependencies
+        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+      - name: Build with Hugo
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo mod tidy
+          hugo \
+            --minify \
+            --baseURL "https://douyixuan.github.io/"

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -54,7 +54,7 @@ jobs:
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
-          hugo mod get -u && \
+          hugo mod tidy
           hugo \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"

--- a/content/posts/compiler/gpu-simt-arch.md
+++ b/content/posts/compiler/gpu-simt-arch.md
@@ -9,10 +9,12 @@ categories:
 tags:
   - compiler
   - gpu-simt-arch
+---
 
 尽可能具体地解释 SIMT 架构在 NVIDIA GPU（使用 CUDA 术语）中的分层和硬件资源管理。
 
 想象一个金字塔结构，从最底层的物理执行单元开始向上构建：
+
 ---
 ### 1. CUDA Core (或 Stream Processor / ALU) - 最底层的计算单元
 


### PR DESCRIPTION
### Motivation
- Add a lightweight CI job to validate Hugo site builds on PRs and via manual dispatch. 
- Replace a potentially unsafe module update with a deterministic tidying step and correct a malformed blog post frontmatter to ensure the site builds cleanly.

### Description
- Add a new workflow `/.github/workflows/hugo-build-test.yml` that installs Hugo and Dart Sass, checks out the repository with submodules, optionally installs Node dependencies, runs `hugo mod tidy`, and builds the site with `hugo` for PR validation. 
- Update `/.github/workflows/hugo.yml` to use `hugo mod tidy` instead of `hugo mod get -u` before running the production build. 
- Fix `content/posts/compiler/gpu-simt-arch.md` by adding the missing closing frontmatter delimiter and adjusting content formatting so the markdown frontmatter is valid.

### Testing
- No automated tests were executed as part of this change; the new workflow is configured to run on `pull_request` and `workflow_dispatch` once merged or triggered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fec82be3e48329891cdee9b672a041)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated build test workflow that validates the site builds successfully on every pull request
  * Updated Hugo module dependency management for improved build reliability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/douyixuan/douyixuan.github.io/pull/9)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->